### PR TITLE
Allows tasty-1.4

### DIFF
--- a/tasty-lua.cabal
+++ b/tasty-lua.cabal
@@ -31,7 +31,7 @@ library
                      , bytestring  >= 0.10.2 && < 0.11
                      , file-embed  >= 0.0    && < 0.1
                      , hslua       >= 1.0.3  && < 1.4
-                     , tasty       >= 1.2    && < 1.4
+                     , tasty       >= 1.2    && < 1.5
                      , text        >= 1.0    && < 1.3
   exposed-modules:     Test.Tasty.Lua
                      , Test.Tasty.Lua.Core


### PR DESCRIPTION
Related to commercialhaskell/stackage#5795; ~I haven't tested this locally, I just figured it would be easy to make the change and let CI yell at me if something broke~.

EDIT: I've since pulled this down and locally verified that `tasty-lua` builds and passes tests w/ `tasty-1.4`.